### PR TITLE
forgot to add a default prop

### DIFF
--- a/src/MuiItems/DetailsPanel.js
+++ b/src/MuiItems/DetailsPanel.js
@@ -42,6 +42,7 @@ DetailsPanel.defaultProps = {
   subtitleVariant: 'body2',
   subtitleLink: null,
   subtitle: null,
+  iconProps: {},
 };
 
 DetailsPanel.propTypes = {


### PR DESCRIPTION
@kbi-daniel Its a good thing you wanted to publish 0.3.23, because I was missing a default prop on the details component.