### PR TITLE
Error boundary

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kbi/component-library",
-  "version": "0.5.6",
+  "version": "0.6.0",
   "description": "A library of all reusable KBI components and utilities.",
   "repository": "https://github.com/KBI-Recycling/component-library",
   "main": "dist/index.js",

--- a/src/MuiItems/ErrorBoundary.js
+++ b/src/MuiItems/ErrorBoundary.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {Grid, Typography} from '@material-ui/core';
+import {NotInterested} from '@material-ui/icons';
+
+class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      hasError: this.props.hasErrorProp ? this.props.hasErrorProp : false,
+    };
+  }
+
+  componentDidCatch(error, info) {
+    this.setState({hasError: true});
+    this.props.errorHandlerFunction(error, info);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <Grid container spacing={4} style={{textAlign: 'center', paddingTop: '24px'}}>
+          <Grid item xs={12}>
+            <NotInterested style={{fontSize: '10em', fill: 'slategray'}} />
+          </Grid>
+          <Grid item xs={12}>
+            <Typography variant='h6'>Oops!</Typography>
+          </Grid>
+          <Grid item xs={12}>
+            <Typography variant='body1'>We encountered an error. Please reload the page.</Typography>
+          </Grid>
+        </Grid>);
+    }
+    return this.props.children;
+  }
+}
+
+ErrorBoundary.propTypes = {
+  /** The content that gets rendered when there is no error. Wrap whatever you want to be caught by this ErrorBoundary */
+  children: PropTypes.object.isRequired,
+  /** The function that triggers in the componentDidCatch. For example, trigger email to devs for error. */
+  errorHandlerFunction: PropTypes.func.isRequired,
+  /** this is used just for the demo version. It could be used by component, but it breaks the use case for it */
+  hasErrorProp: PropTypes.bool,
+};
+
+export default ErrorBoundary;

--- a/src/MuiItems/ErrorBoundary.md
+++ b/src/MuiItems/ErrorBoundary.md
@@ -1,0 +1,13 @@
+Error Boundary Example
+```js
+import React from 'react';
+
+  <ErrorBoundary errorHandlerFunction={(error, info) => {
+      console.log('error', error);
+      console.log('info', info);
+    }}
+    hasErrorProp={true}
+  >
+    <h1>Child element</h1>
+  </ErrorBoundary>
+```

--- a/src/index.js
+++ b/src/index.js
@@ -40,6 +40,9 @@ export * from './MuiItems/DetailsPanel.js';
 export {default as AppFrame} from './MuiItems/AppFrame.js';
 export * from './MuiItems/AppFrame.js';
 
+export {default as ErrorBoundary} from './MuiItems/ErrorBoundary.js';
+export * from './MuiItems/ErrorBoundary.js';
+
 export const Formik = {
   FormikForm,
   SubmitButton,

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -22,6 +22,7 @@ module.exports = {
         'src/MuiItems/DetailsPanel.js',
         'src/MuiItems/AppFrame.js',
         'src/MuiItems/NotesPanel.js',
+        'src/MuiItems/ErrorBoundary.js',
       ],
     },
     {


### PR DESCRIPTION
This is a general use error boundary. It is a static page that displays this on error:

![errorBoundary](https://user-images.githubusercontent.com/28384528/105769718-15d17d00-5f13-11eb-8f89-1061c0450cc0.PNG)

It can be passed a function as a prop that will run on componentDidCatch. The general use will be to send an error email to the developers that an error occurred.
